### PR TITLE
Use find instead of all

### DIFF
--- a/example/authorizationServer.js
+++ b/example/authorizationServer.js
@@ -412,7 +412,7 @@ app.post("/token", function(req, res){
 		return;	
 		
 	} else if (req.body.grant_type == 'refresh_token') {
-	nosql.all().make(function(builder) {
+	nosql.find().make(function(builder) {
 	  builder.where('refresh_token', req.body.refresh_token);
 	  builder.callback(function(err, tokens) {
 			if (tokens.length == 1) {

--- a/example/chapter10/authorizationServer.js
+++ b/example/chapter10/authorizationServer.js
@@ -423,7 +423,7 @@ app.post("/token", function(req, res){
 		return;	
 		
 	} else if (req.body.grant_type == 'refresh_token') {
-	nosql.all().make(function(builder) {
+	nosql.find().make(function(builder) {
 	  builder.where('refresh_token', req.body.refresh_token);
 	  builder.callback(function(err, tokens) {
 			if (tokens.length == 1) {

--- a/example/chapter8/authorizationServer.js
+++ b/example/chapter8/authorizationServer.js
@@ -413,7 +413,7 @@ app.post("/token", function(req, res){
 		return;	
 		
 	} else if (req.body.grant_type == 'refresh_token') {
-	nosql.all().make(function(builder) {
+	nosql.find().make(function(builder) {
 	  builder.where('refresh_token', req.body.refresh_token);
 	  builder.callback(function(err, tokens) {
 			if (tokens.length == 1) {

--- a/exercises/ch-3-ex-2/authorizationServer.js
+++ b/exercises/ch-3-ex-2/authorizationServer.js
@@ -219,7 +219,7 @@ app.post("/token", function(req, res){
 			return;
 		}
 	} else if (req.body.grant_type == 'refresh_token') {
-  	nosql.all().make(function(builder) {
+  	nosql.find().make(function(builder) {
   	  builder.where('refresh_token', req.body.refresh_token);
   	  builder.callback(function(err, tokens) {
   			if (tokens.length == 1) {

--- a/exercises/ch-4-ex-1/authorizationServer.js
+++ b/exercises/ch-4-ex-1/authorizationServer.js
@@ -328,7 +328,7 @@ app.post("/token", function(req, res){
 		return;	
 		
 	} else if (req.body.grant_type == 'refresh_token') {
-	nosql.all().make(function(builder) {
+	nosql.find().make(function(builder) {
 	  builder.where('refresh_token', req.body.refresh_token);
 	  builder.callback(function(err, tokens) {
 			if (tokens.length == 1) {

--- a/exercises/ch-4-ex-2/authorizationServer.js
+++ b/exercises/ch-4-ex-2/authorizationServer.js
@@ -328,7 +328,7 @@ app.post("/token", function(req, res){
 		return;	
 		
 	} else if (req.body.grant_type == 'refresh_token') {
-	nosql.all().make(function(builder) {
+	nosql.find().make(function(builder) {
 	  builder.where('refresh_token', req.body.refresh_token);
 	  builder.callback(function(err, tokens) {
 			if (tokens.length == 1) {

--- a/exercises/ch-4-ex-3/authorizationServer.js
+++ b/exercises/ch-4-ex-3/authorizationServer.js
@@ -328,7 +328,7 @@ app.post("/token", function(req, res){
 		return;	
 		
 	} else if (req.body.grant_type == 'refresh_token') {
-	nosql.all().make(function(builder) {
+	nosql.find().make(function(builder) {
 	  builder.where('refresh_token', req.body.refresh_token);
 	  builder.callback(function(err, tokens) {
 			if (tokens.length == 1) {

--- a/exercises/ch-4-ex-4/authorizationServer.js
+++ b/exercises/ch-4-ex-4/authorizationServer.js
@@ -334,7 +334,7 @@ app.post("/token", function(req, res){
 		return;	
 		
 	} else if (req.body.grant_type == 'refresh_token') {
-	nosql.all().make(function(builder) {
+	nosql.find().make(function(builder) {
 	  builder.where('refresh_token', req.body.refresh_token);
 	  builder.callback(function(err, tokens) {
 			if (tokens.length == 1) {

--- a/exercises/ch-6-ex-5/authorizationServer.js
+++ b/exercises/ch-6-ex-5/authorizationServer.js
@@ -413,7 +413,7 @@ app.post("/token", function(req, res){
 		return;	
 		
 	} else if (req.body.grant_type == 'refresh_token') {
-	nosql.all().make(function(builder) {
+	nosql.find().make(function(builder) {
 	  builder.where('refresh_token', req.body.refresh_token);
 	  builder.callback(function(err, tokens) {
 			if (tokens.length == 1) {

--- a/exercises/ch-7-ex-1/authorizationServer.js
+++ b/exercises/ch-7-ex-1/authorizationServer.js
@@ -413,7 +413,7 @@ app.post("/token", function(req, res){
 		return;	
 		
 	} else if (req.body.grant_type == 'refresh_token') {
-	nosql.all().make(function(builder) {
+	nosql.find().make(function(builder) {
 	  builder.where('refresh_token', req.body.refresh_token);
 	  builder.callback(function(err, tokens) {
 			if (tokens.length == 1) {

--- a/exercises/ch-8-ex-1/authorizationServer.js
+++ b/exercises/ch-8-ex-1/authorizationServer.js
@@ -413,7 +413,7 @@ app.post("/token", function(req, res){
 		return;	
 		
 	} else if (req.body.grant_type == 'refresh_token') {
-	nosql.all().make(function(builder) {
+	nosql.find().make(function(builder) {
 	  builder.where('refresh_token', req.body.refresh_token);
 	  builder.callback(function(err, tokens) {
 			if (tokens.length == 1) {

--- a/exercises/ch-8-ex-2/authorizationServer.js
+++ b/exercises/ch-8-ex-2/authorizationServer.js
@@ -413,7 +413,7 @@ app.post("/token", function(req, res){
 		return;	
 		
 	} else if (req.body.grant_type == 'refresh_token') {
-	nosql.all().make(function(builder) {
+	nosql.find().make(function(builder) {
 	  builder.where('refresh_token', req.body.refresh_token);
 	  builder.callback(function(err, tokens) {
 			if (tokens.length == 1) {

--- a/exercises/ch-8-ex-3/authorizationServer.js
+++ b/exercises/ch-8-ex-3/authorizationServer.js
@@ -413,7 +413,7 @@ app.post("/token", function(req, res){
 		return;	
 		
 	} else if (req.body.grant_type == 'refresh_token') {
-	nosql.all().make(function(builder) {
+	nosql.find().make(function(builder) {
 	  builder.where('refresh_token', req.body.refresh_token);
 	  builder.callback(function(err, tokens) {
 			if (tokens.length == 1) {


### PR DESCRIPTION
While I'm doing the exercises from the book, I'm getting the following exception; this PR is a fix for that:
```
TypeError: nosql.all is not a function
    at /home/test/Data/Projects/oauth-in-action-code/exercises/ch-3-ex-2/authorizationServer.js:223:9
    at Layer.handle [as handle_request] (/home/test/Data/Projects/oauth-in-action-code/exercises/ch-3-ex-2/node_modules/express/lib/router/layer.js:95:5)
    at next (/home/test/Data/Projects/oauth-in-action-code/exercises/ch-3-ex-2/node_modules/express/lib/router/route.js:137:13)
    at Route.dispatch (/home/test/Data/Projects/oauth-in-action-code/exercises/ch-3-ex-2/node_modules/express/lib/router/route.js:112:3)
    at Layer.handle [as handle_request] (/home/test/Data/Projects/oauth-in-action-code/exercises/ch-3-ex-2/node_modules/express/lib/router/layer.js:95:5)
    at /home/test/Data/Projects/oauth-in-action-code/exercises/ch-3-ex-2/node_modules/express/lib/router/index.js:281:22
    at Function.process_params (/home/test/Data/Projects/oauth-in-action-code/exercises/ch-3-ex-2/node_modules/express/lib/router/index.js:335:12)
    at next (/home/test/Data/Projects/oauth-in-action-code/exercises/ch-3-ex-2/node_modules/express/lib/router/index.js:275:10)
    at /home/test/Data/Projects/oauth-in-action-code/exercises/ch-3-ex-2/node_modules/body-parser/lib/read.js:130:5
    at invokeCallback (/home/test/Data/Projects/oauth-in-action-code/exercises/ch-3-ex-2/node_modules/raw-body/index.js:224:16)
    at done (/home/test/Data/Projects/oauth-in-action-code/exercises/ch-3-ex-2/node_modules/raw-body/index.js:213:7)
    at IncomingMessage.onEnd (/home/test/Data/Projects/oauth-in-action-code/exercises/ch-3-ex-2/node_modules/raw-body/index.js:273:7)
    at IncomingMessage.emit (events.js:327:22)
    at endReadableNT (_stream_readable.js:1327:12)
    at processTicksAndRejections (internal/process/task_queues.js:80:21)
```