### PR TITLE
fix: typo for the variable name for the protected resource's credential

### DIFF
--- a/exercises/ch-11-ex-4/protectedResource.js
+++ b/exercises/ch-11-ex-4/protectedResource.js
@@ -24,9 +24,9 @@ var resource = {
 	"description": "This data has been protected by OAuth 2.0"
 };
 
-var protectedResources = {
-		"resource_id": "protected-resource-1",
-		"resource_secret": "protected-resource-secret-1"
+var protectedResource = {
+	"resource_id": "protected-resource-1",
+	"resource_secret": "protected-resource-secret-1"
 };
 
 var authServer = {


### PR DESCRIPTION
The variable name used in the book is `protectedResource`.

<img width="975" alt="截圖 2023-01-26 下午11 54 48" src="https://user-images.githubusercontent.com/16910748/214883663-c128a77e-c940-4100-ab15-70f9b0668866.png">
