### PR TITLE
change(ch-12-ex-2): fix the deletion part for a dynamic registration

### DIFF
--- a/exercises/ch-12-ex-2/completed/authorizationServer.js
+++ b/exercises/ch-12-ex-2/completed/authorizationServer.js
@@ -401,7 +401,7 @@ app.delete('/register/:clientId', authorizeConfigurationEndpointRequest, functio
 	clients = __.reject(clients, __.matches({client_id: req.client.client_id}));
 
   nosql.remove().make(function(builder) {
-    builder.where('client_id', clientId);
+    builder.where('client_id', req.client.clientId);
     builder.callback(function(err, count) {
       console.log("Removed %s tokens", count);
     });


### PR DESCRIPTION
Thank you so much for providing a great book and code!

Since there is a broken variable reference in the deletion part for dynamic registration, this PR fixes it.

FYI: This change has been accidentally introduced in updating remove calls for nosql in [this commit](https://github.com/oauthinaction/oauth-in-action-code/commit/2fdcd98b5b261f972f1d1b6ca92cde80cec9d64a#diff-efb5240bb7b4d084510b9f14ca0cfb317ce8136a4d0892e962c31e4b5c228ff3R404).

### Screenshots
#### Before
![before](https://github.com/oauthinaction/oauth-in-action-code/assets/29667656/869c0336-db58-4da7-bdb8-09df8703a4e4)

#### After
![after](https://github.com/oauthinaction/oauth-in-action-code/assets/29667656/056000d2-1bed-49d0-9420-90c326b4a1fe)
