### PR TITLE
fix all typo 'reponse_types' to 'response_types'

### DIFF
--- a/example/authorizationServer.js
+++ b/example/authorizationServer.js
@@ -600,7 +600,7 @@ var checkClientMetadata = function (req, res) {
 			}
 		} else {
 			reg.grant_types = req.body.grant_types;
-			reg.reponse_types = req.body.response_types;
+			reg.response_types = req.body.response_types;
 			if (__.contains(req.body.grant_types, 'authorization_code') && !__.contains(req.body.response_types, 'code')) {
 				reg.response_types.push('code');
 			}

--- a/example/chapter10/authorizationServer.js
+++ b/example/chapter10/authorizationServer.js
@@ -611,7 +611,7 @@ var checkClientMetadata = function (req, res) {
 			}
 		} else {
 			reg.grant_types = req.body.grant_types;
-			reg.reponse_types = req.body.response_types;
+			reg.response_types = req.body.response_types;
 			if (__.contains(req.body.grant_types, 'authorization_code') && !__.contains(req.body.response_types, 'code')) {
 				reg.response_types.push('code');
 			}

--- a/example/chapter8/authorizationServer.js
+++ b/example/chapter8/authorizationServer.js
@@ -601,7 +601,7 @@ var checkClientMetadata = function (req, res) {
 			}
 		} else {
 			reg.grant_types = req.body.grant_types;
-			reg.reponse_types = req.body.response_types;
+			reg.response_types = req.body.response_types;
 			if (__.contains(req.body.grant_types, 'authorization_code') && !__.contains(req.body.response_types, 'code')) {
 				reg.response_types.push('code');
 			}

--- a/exercises/ch-12-ex-1/completed/authorizationServer.js
+++ b/exercises/ch-12-ex-1/completed/authorizationServer.js
@@ -275,7 +275,7 @@ app.post('/register', function (req, res){
 			}
 		} else {
 			reg.grant_types = req.body.grant_types;
-			reg.reponse_types = req.body.response_types;
+			reg.response_types = req.body.response_types;
 			if (__.contains(req.body.grant_types, 'authorization_code') && !__.contains(req.body.response_types, 'code')) {
 				reg.response_types.push('code');
 			}

--- a/exercises/ch-12-ex-2/authorizationServer.js
+++ b/exercises/ch-12-ex-2/authorizationServer.js
@@ -274,7 +274,7 @@ var checkClientMetadata = function(req, res) {
 			}
 		} else {
 			reg.grant_types = req.body.grant_types;
-			reg.reponse_types = req.body.response_types;
+			reg.response_types = req.body.response_types;
 			if (__.contains(req.body.grant_types, 'authorization_code') && !__.contains(req.body.response_types, 'code')) {
 				reg.response_types.push('code');
 			}

--- a/exercises/ch-12-ex-2/completed/authorizationServer.js
+++ b/exercises/ch-12-ex-2/completed/authorizationServer.js
@@ -274,7 +274,7 @@ var checkClientMetadata = function(req, res) {
 			}
 		} else {
 			reg.grant_types = req.body.grant_types;
-			reg.reponse_types = req.body.response_types;
+			reg.response_types = req.body.response_types;
 			if (__.contains(req.body.grant_types, 'authorization_code') && !__.contains(req.body.response_types, 'code')) {
 				reg.response_types.push('code');
 			}

--- a/exercises/ch-6-ex-5/authorizationServer.js
+++ b/exercises/ch-6-ex-5/authorizationServer.js
@@ -601,7 +601,7 @@ var checkClientMetadata = function (req, res) {
 			}
 		} else {
 			reg.grant_types = req.body.grant_types;
-			reg.reponse_types = req.body.response_types;
+			reg.response_types = req.body.response_types;
 			if (__.contains(req.body.grant_types, 'authorization_code') && !__.contains(req.body.response_types, 'code')) {
 				reg.response_types.push('code');
 			}

--- a/exercises/ch-7-ex-1/authorizationServer.js
+++ b/exercises/ch-7-ex-1/authorizationServer.js
@@ -601,7 +601,7 @@ var checkClientMetadata = function (req, res) {
 			}
 		} else {
 			reg.grant_types = req.body.grant_types;
-			reg.reponse_types = req.body.response_types;
+			reg.response_types = req.body.response_types;
 			if (__.contains(req.body.grant_types, 'authorization_code') && !__.contains(req.body.response_types, 'code')) {
 				reg.response_types.push('code');
 			}

--- a/exercises/ch-8-ex-1/authorizationServer.js
+++ b/exercises/ch-8-ex-1/authorizationServer.js
@@ -601,7 +601,7 @@ var checkClientMetadata = function (req, res) {
 			}
 		} else {
 			reg.grant_types = req.body.grant_types;
-			reg.reponse_types = req.body.response_types;
+			reg.response_types = req.body.response_types;
 			if (__.contains(req.body.grant_types, 'authorization_code') && !__.contains(req.body.response_types, 'code')) {
 				reg.response_types.push('code');
 			}

--- a/exercises/ch-8-ex-2/authorizationServer.js
+++ b/exercises/ch-8-ex-2/authorizationServer.js
@@ -601,7 +601,7 @@ var checkClientMetadata = function (req, res) {
 			}
 		} else {
 			reg.grant_types = req.body.grant_types;
-			reg.reponse_types = req.body.response_types;
+			reg.response_types = req.body.response_types;
 			if (__.contains(req.body.grant_types, 'authorization_code') && !__.contains(req.body.response_types, 'code')) {
 				reg.response_types.push('code');
 			}

--- a/exercises/ch-8-ex-3/authorizationServer.js
+++ b/exercises/ch-8-ex-3/authorizationServer.js
@@ -601,7 +601,7 @@ var checkClientMetadata = function (req, res) {
 			}
 		} else {
 			reg.grant_types = req.body.grant_types;
-			reg.reponse_types = req.body.response_types;
+			reg.response_types = req.body.response_types;
 			if (__.contains(req.body.grant_types, 'authorization_code') && !__.contains(req.body.response_types, 'code')) {
 				reg.response_types.push('code');
 			}


### PR DESCRIPTION
I found that the "register" function of AuthorizationServer had implemented the wrong variable name 'reponse_types' for a long time.

Please review these typos, thanks.