### PR TITLE
fix the wrong token_endpoint_auth_method: 'secret_basic' to 'client_secret_basic' and 'secret_post' to 'client_secret_post'

### DIFF
--- a/example/authorizationServer.js
+++ b/example/authorizationServer.js
@@ -568,12 +568,12 @@ var checkClientMetadata = function (req, res) {
 	var reg = {};
 
 	if (!req.body.token_endpoint_auth_method) {
-		reg.token_endpoint_auth_method = 'secret_basic';	
+		reg.token_endpoint_auth_method = 'client_secret_basic';	
 	} else {
 		reg.token_endpoint_auth_method = req.body.token_endpoint_auth_method;
 	}
 	
-	if (!__.contains(['secret_basic', 'secret_post', 'none'], reg.token_endpoint_auth_method)) {
+	if (!__.contains(['client_secret_basic', 'client_secret_post', 'none'], reg.token_endpoint_auth_method)) {
 		res.status(400).json({error: 'invalid_client_metadata'});
 		return;
 	}
@@ -650,7 +650,7 @@ app.post('/register', function (req, res){
 	}
 
 	reg.client_id = randomstring.generate();
-	if (__.contains(['secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
+	if (__.contains(['client_secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
 		reg.client_secret = randomstring.generate();
 	}
 

--- a/example/authorizationServer.js
+++ b/example/authorizationServer.js
@@ -650,7 +650,7 @@ app.post('/register', function (req, res){
 	}
 
 	reg.client_id = randomstring.generate();
-	if (__.contains(['client_secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
+	if (__.contains(['secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
 		reg.client_secret = randomstring.generate();
 	}
 

--- a/example/chapter10/authorizationServer.js
+++ b/example/chapter10/authorizationServer.js
@@ -579,12 +579,12 @@ var checkClientMetadata = function (req, res) {
 	var reg = {};
 
 	if (!req.body.token_endpoint_auth_method) {
-		reg.token_endpoint_auth_method = 'secret_basic';	
+		reg.token_endpoint_auth_method = 'client_secret_basic';	
 	} else {
 		reg.token_endpoint_auth_method = req.body.token_endpoint_auth_method;
 	}
 	
-	if (!__.contains(['secret_basic', 'secret_post', 'none'], reg.token_endpoint_auth_method)) {
+	if (!__.contains(['client_secret_basic', 'client_secret_post', 'none'], reg.token_endpoint_auth_method)) {
 		res.status(400).json({error: 'invalid_client_metadata'});
 		return;
 	}
@@ -661,7 +661,7 @@ app.post('/register', function (req, res){
 	}
 
 	reg.client_id = randomstring.generate();
-	if (__.contains(['secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
+	if (__.contains(['client_secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
 		reg.client_secret = randomstring.generate();
 	}
 

--- a/example/chapter10/authorizationServer.js
+++ b/example/chapter10/authorizationServer.js
@@ -661,7 +661,7 @@ app.post('/register', function (req, res){
 	}
 
 	reg.client_id = randomstring.generate();
-	if (__.contains(['client_secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
+	if (__.contains(['secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
 		reg.client_secret = randomstring.generate();
 	}
 

--- a/example/chapter10/client.js
+++ b/example/chapter10/client.js
@@ -101,7 +101,7 @@ var registerClient = function() {
 		redirect_uris: ['http://localhost:9000/callback'],
 		grant_types: ['authorization_code'],
 		response_types: ['code'],
-		token_endpoint_auth_method: 'secret_basic',
+		token_endpoint_auth_method: 'client_secret_basic',
 		scope: 'openid profile email address phone'
 	};
 

--- a/example/chapter8/authorizationServer.js
+++ b/example/chapter8/authorizationServer.js
@@ -651,7 +651,7 @@ app.post('/register', function (req, res){
 	}
 
 	reg.client_id = randomstring.generate();
-	if (__.contains(['client_secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
+	if (__.contains(['secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
 		reg.client_secret = randomstring.generate();
 	}
 

--- a/example/chapter8/authorizationServer.js
+++ b/example/chapter8/authorizationServer.js
@@ -569,12 +569,12 @@ var checkClientMetadata = function (req, res) {
 	var reg = {};
 
 	if (!req.body.token_endpoint_auth_method) {
-		reg.token_endpoint_auth_method = 'secret_basic';	
+		reg.token_endpoint_auth_method = 'client_secret_basic';	
 	} else {
 		reg.token_endpoint_auth_method = req.body.token_endpoint_auth_method;
 	}
 	
-	if (!__.contains(['secret_basic', 'secret_post', 'none'], reg.token_endpoint_auth_method)) {
+	if (!__.contains(['client_secret_basic', 'client_secret_post', 'none'], reg.token_endpoint_auth_method)) {
 		res.status(400).json({error: 'invalid_client_metadata'});
 		return;
 	}
@@ -651,7 +651,7 @@ app.post('/register', function (req, res){
 	}
 
 	reg.client_id = randomstring.generate();
-	if (__.contains(['secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
+	if (__.contains(['client_secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
 		reg.client_secret = randomstring.generate();
 	}
 

--- a/example/chapter8/client.js
+++ b/example/chapter8/client.js
@@ -98,7 +98,7 @@ var registerClient = function() {
 		redirect_uris: ['http://localhost:9000/callback'],
 		grant_types: ['authorization_code'],
 		response_types: ['code'],
-		token_endpoint_auth_method: 'secret_basic',
+		token_endpoint_auth_method: 'client_secret_basic',
 		scope: 'openid profile email address phone'
 	};
 

--- a/example/client.js
+++ b/example/client.js
@@ -100,7 +100,7 @@ var registerClient = function() {
 		redirect_uris: ['http://localhost:9000/callback'],
 		grant_types: ['authorization_code'],
 		response_types: ['code'],
-		token_endpoint_auth_method: 'secret_basic',
+		token_endpoint_auth_method: 'client_secret_basic',
 		scope: 'openid profile email address phone'
 	};
 

--- a/exercises/ch-11-ex-4/client.js
+++ b/exercises/ch-11-ex-4/client.js
@@ -98,7 +98,7 @@ var registerClient = function() {
 		redirect_uris: ['http://localhost:9000/callback'],
 		grant_types: ['authorization_code'],
 		response_types: ['code'],
-		token_endpoint_auth_method: 'secret_basic',
+		token_endpoint_auth_method: 'client_secret_basic',
 		scope: 'openid profile email address phone'
 	};
 

--- a/exercises/ch-12-ex-1/completed/authorizationServer.js
+++ b/exercises/ch-12-ex-1/completed/authorizationServer.js
@@ -243,12 +243,12 @@ app.post('/register', function (req, res){
 	var reg = {};
 
 	if (!req.body.token_endpoint_auth_method) {
-		reg.token_endpoint_auth_method = 'secret_basic';	
+		reg.token_endpoint_auth_method = 'client_secret_basic';	
 	} else {
 		reg.token_endpoint_auth_method = req.body.token_endpoint_auth_method;
 	}
 	
-	if (!__.contains(['secret_basic', 'secret_post', 'none'], reg.token_endpoint_auth_method)) {
+	if (!__.contains(['client_secret_basic', 'client_secret_post', 'none'], reg.token_endpoint_auth_method)) {
 		res.status(400).json({error: 'invalid_client_metadata'});
 		return;
 	}
@@ -315,7 +315,7 @@ app.post('/register', function (req, res){
 	}
 	
 	reg.client_id = randomstring.generate();
-	if (__.contains(['secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
+	if (__.contains(['client_secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
 		reg.client_secret = randomstring.generate();
 	}
 

--- a/exercises/ch-12-ex-1/completed/authorizationServer.js
+++ b/exercises/ch-12-ex-1/completed/authorizationServer.js
@@ -315,7 +315,7 @@ app.post('/register', function (req, res){
 	}
 	
 	reg.client_id = randomstring.generate();
-	if (__.contains(['client_secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
+	if (__.contains(['secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
 		reg.client_secret = randomstring.generate();
 	}
 

--- a/exercises/ch-12-ex-1/completed/client.js
+++ b/exercises/ch-12-ex-1/completed/client.js
@@ -175,7 +175,7 @@ var registerClient = function() {
 		redirect_uris: ['http://localhost:9000/callback'],
 		grant_types: ['authorization_code'],
 		response_types: ['code'],
-		token_endpoint_auth_method: 'secret_basic',
+		token_endpoint_auth_method: 'client_secret_basic',
 		scope: 'foo bar'
 	};
 

--- a/exercises/ch-12-ex-2/authorizationServer.js
+++ b/exercises/ch-12-ex-2/authorizationServer.js
@@ -314,7 +314,7 @@ var checkClientMetadata = function(req, res) {
 	}
 	
 	reg.client_id = randomstring.generate();
-	if (__.contains(['client_secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
+	if (__.contains(['secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
 		reg.client_secret = randomstring.generate();
 	}
 	

--- a/exercises/ch-12-ex-2/authorizationServer.js
+++ b/exercises/ch-12-ex-2/authorizationServer.js
@@ -242,12 +242,12 @@ var checkClientMetadata = function(req, res) {
 	var reg = {};
 
 	if (!req.body.token_endpoint_auth_method) {
-		reg.token_endpoint_auth_method = 'secret_basic';	
+		reg.token_endpoint_auth_method = 'client_secret_basic';	
 	} else {
 		reg.token_endpoint_auth_method = req.body.token_endpoint_auth_method;
 	}
 	
-	if (!__.contains(['secret_basic', 'secret_post', 'none'], reg.token_endpoint_auth_method)) {
+	if (!__.contains(['client_secret_basic', 'client_secret_post', 'none'], reg.token_endpoint_auth_method)) {
 		res.status(400).json({error: 'invalid_client_metadata'});
 		return;
 	}
@@ -314,7 +314,7 @@ var checkClientMetadata = function(req, res) {
 	}
 	
 	reg.client_id = randomstring.generate();
-	if (__.contains(['secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
+	if (__.contains(['client_secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
 		reg.client_secret = randomstring.generate();
 	}
 	

--- a/exercises/ch-12-ex-2/client.js
+++ b/exercises/ch-12-ex-2/client.js
@@ -175,7 +175,7 @@ var registerClient = function() {
 		redirect_uris: ['http://localhost:9000/callback'],
 		grant_types: ['authorization_code'],
 		response_types: ['code'],
-		token_endpoint_auth_method: 'secret_basic',
+		token_endpoint_auth_method: 'client_secret_basic',
 		scope: 'foo bar'
 	};
 

--- a/exercises/ch-12-ex-2/completed/authorizationServer.js
+++ b/exercises/ch-12-ex-2/completed/authorizationServer.js
@@ -242,12 +242,12 @@ var checkClientMetadata = function(req, res) {
 	var reg = {};
 
 	if (!req.body.token_endpoint_auth_method) {
-		reg.token_endpoint_auth_method = 'secret_basic';	
+		reg.token_endpoint_auth_method = 'client_secret_basic';	
 	} else {
 		reg.token_endpoint_auth_method = req.body.token_endpoint_auth_method;
 	}
 	
-	if (!__.contains(['secret_basic', 'secret_post', 'none'], reg.token_endpoint_auth_method)) {
+	if (!__.contains(['client_secret_basic', 'client_secret_post', 'none'], reg.token_endpoint_auth_method)) {
 		res.status(400).json({error: 'invalid_client_metadata'});
 		return;
 	}
@@ -324,7 +324,7 @@ app.post('/register', function (req, res){
 	}
 	
 	reg.client_id = randomstring.generate();
-	if (__.contains(['secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
+	if (__.contains(['client_secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
 		reg.client_secret = randomstring.generate();
 	}
 	

--- a/exercises/ch-12-ex-2/completed/authorizationServer.js
+++ b/exercises/ch-12-ex-2/completed/authorizationServer.js
@@ -324,7 +324,7 @@ app.post('/register', function (req, res){
 	}
 	
 	reg.client_id = randomstring.generate();
-	if (__.contains(['client_secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
+	if (__.contains(['secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
 		reg.client_secret = randomstring.generate();
 	}
 	

--- a/exercises/ch-12-ex-2/completed/client.js
+++ b/exercises/ch-12-ex-2/completed/client.js
@@ -175,7 +175,7 @@ var registerClient = function() {
 		redirect_uris: ['http://localhost:9000/callback'],
 		grant_types: ['authorization_code'],
 		response_types: ['code'],
-		token_endpoint_auth_method: 'secret_basic',
+		token_endpoint_auth_method: 'client_secret_basic',
 		scope: 'foo bar'
 	};
 

--- a/exercises/ch-6-ex-5/authorizationServer.js
+++ b/exercises/ch-6-ex-5/authorizationServer.js
@@ -651,7 +651,7 @@ app.post('/register', function (req, res){
 	}
 
 	reg.client_id = randomstring.generate();
-	if (__.contains(['client_secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
+	if (__.contains(['secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
 		reg.client_secret = randomstring.generate();
 	}
 

--- a/exercises/ch-6-ex-5/authorizationServer.js
+++ b/exercises/ch-6-ex-5/authorizationServer.js
@@ -569,12 +569,12 @@ var checkClientMetadata = function (req, res) {
 	var reg = {};
 
 	if (!req.body.token_endpoint_auth_method) {
-		reg.token_endpoint_auth_method = 'secret_basic';	
+		reg.token_endpoint_auth_method = 'client_secret_basic';	
 	} else {
 		reg.token_endpoint_auth_method = req.body.token_endpoint_auth_method;
 	}
 	
-	if (!__.contains(['secret_basic', 'secret_post', 'none'], reg.token_endpoint_auth_method)) {
+	if (!__.contains(['client_secret_basic', 'client_secret_post', 'none'], reg.token_endpoint_auth_method)) {
 		res.status(400).json({error: 'invalid_client_metadata'});
 		return;
 	}
@@ -651,7 +651,7 @@ app.post('/register', function (req, res){
 	}
 
 	reg.client_id = randomstring.generate();
-	if (__.contains(['secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
+	if (__.contains(['client_secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
 		reg.client_secret = randomstring.generate();
 	}
 

--- a/exercises/ch-7-ex-1/authorizationServer.js
+++ b/exercises/ch-7-ex-1/authorizationServer.js
@@ -651,7 +651,7 @@ app.post('/register', function (req, res){
 	}
 
 	reg.client_id = randomstring.generate();
-	if (__.contains(['client_secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
+	if (__.contains(['secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
 		reg.client_secret = randomstring.generate();
 	}
 

--- a/exercises/ch-7-ex-1/authorizationServer.js
+++ b/exercises/ch-7-ex-1/authorizationServer.js
@@ -569,12 +569,12 @@ var checkClientMetadata = function (req, res) {
 	var reg = {};
 
 	if (!req.body.token_endpoint_auth_method) {
-		reg.token_endpoint_auth_method = 'secret_basic';	
+		reg.token_endpoint_auth_method = 'client_secret_basic';	
 	} else {
 		reg.token_endpoint_auth_method = req.body.token_endpoint_auth_method;
 	}
 	
-	if (!__.contains(['secret_basic', 'secret_post', 'none'], reg.token_endpoint_auth_method)) {
+	if (!__.contains(['client_secret_basic', 'client_secret_post', 'none'], reg.token_endpoint_auth_method)) {
 		res.status(400).json({error: 'invalid_client_metadata'});
 		return;
 	}
@@ -651,7 +651,7 @@ app.post('/register', function (req, res){
 	}
 
 	reg.client_id = randomstring.generate();
-	if (__.contains(['secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
+	if (__.contains(['client_secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
 		reg.client_secret = randomstring.generate();
 	}
 

--- a/exercises/ch-8-ex-1/authorizationServer.js
+++ b/exercises/ch-8-ex-1/authorizationServer.js
@@ -651,7 +651,7 @@ app.post('/register', function (req, res){
 	}
 
 	reg.client_id = randomstring.generate();
-	if (__.contains(['client_secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
+	if (__.contains(['secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
 		reg.client_secret = randomstring.generate();
 	}
 

--- a/exercises/ch-8-ex-1/authorizationServer.js
+++ b/exercises/ch-8-ex-1/authorizationServer.js
@@ -569,12 +569,12 @@ var checkClientMetadata = function (req, res) {
 	var reg = {};
 
 	if (!req.body.token_endpoint_auth_method) {
-		reg.token_endpoint_auth_method = 'secret_basic';	
+		reg.token_endpoint_auth_method = 'client_secret_basic';	
 	} else {
 		reg.token_endpoint_auth_method = req.body.token_endpoint_auth_method;
 	}
 	
-	if (!__.contains(['secret_basic', 'secret_post', 'none'], reg.token_endpoint_auth_method)) {
+	if (!__.contains(['client_secret_basic', 'client_secret_post', 'none'], reg.token_endpoint_auth_method)) {
 		res.status(400).json({error: 'invalid_client_metadata'});
 		return;
 	}
@@ -651,7 +651,7 @@ app.post('/register', function (req, res){
 	}
 
 	reg.client_id = randomstring.generate();
-	if (__.contains(['secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
+	if (__.contains(['client_secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
 		reg.client_secret = randomstring.generate();
 	}
 

--- a/exercises/ch-8-ex-1/client.js
+++ b/exercises/ch-8-ex-1/client.js
@@ -98,7 +98,7 @@ var registerClient = function() {
 		redirect_uris: ['http://localhost:9000/callback'],
 		grant_types: ['authorization_code'],
 		response_types: ['code'],
-		token_endpoint_auth_method: 'secret_basic',
+		token_endpoint_auth_method: 'client_secret_basic',
 		scope: 'openid profile email address phone'
 	};
 

--- a/exercises/ch-8-ex-2/authorizationServer.js
+++ b/exercises/ch-8-ex-2/authorizationServer.js
@@ -651,7 +651,7 @@ app.post('/register', function (req, res){
 	}
 
 	reg.client_id = randomstring.generate();
-	if (__.contains(['client_secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
+	if (__.contains(['secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
 		reg.client_secret = randomstring.generate();
 	}
 

--- a/exercises/ch-8-ex-2/authorizationServer.js
+++ b/exercises/ch-8-ex-2/authorizationServer.js
@@ -569,12 +569,12 @@ var checkClientMetadata = function (req, res) {
 	var reg = {};
 
 	if (!req.body.token_endpoint_auth_method) {
-		reg.token_endpoint_auth_method = 'secret_basic';	
+		reg.token_endpoint_auth_method = 'client_secret_basic';	
 	} else {
 		reg.token_endpoint_auth_method = req.body.token_endpoint_auth_method;
 	}
 	
-	if (!__.contains(['secret_basic', 'secret_post', 'none'], reg.token_endpoint_auth_method)) {
+	if (!__.contains(['client_secret_basic', 'client_secret_post', 'none'], reg.token_endpoint_auth_method)) {
 		res.status(400).json({error: 'invalid_client_metadata'});
 		return;
 	}
@@ -651,7 +651,7 @@ app.post('/register', function (req, res){
 	}
 
 	reg.client_id = randomstring.generate();
-	if (__.contains(['secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
+	if (__.contains(['client_secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
 		reg.client_secret = randomstring.generate();
 	}
 

--- a/exercises/ch-8-ex-3/authorizationServer.js
+++ b/exercises/ch-8-ex-3/authorizationServer.js
@@ -651,7 +651,7 @@ app.post('/register', function (req, res){
 	}
 
 	reg.client_id = randomstring.generate();
-	if (__.contains(['client_secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
+	if (__.contains(['secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
 		reg.client_secret = randomstring.generate();
 	}
 

--- a/exercises/ch-8-ex-3/authorizationServer.js
+++ b/exercises/ch-8-ex-3/authorizationServer.js
@@ -569,12 +569,12 @@ var checkClientMetadata = function (req, res) {
 	var reg = {};
 
 	if (!req.body.token_endpoint_auth_method) {
-		reg.token_endpoint_auth_method = 'secret_basic';	
+		reg.token_endpoint_auth_method = 'client_secret_basic';	
 	} else {
 		reg.token_endpoint_auth_method = req.body.token_endpoint_auth_method;
 	}
 	
-	if (!__.contains(['secret_basic', 'secret_post', 'none'], reg.token_endpoint_auth_method)) {
+	if (!__.contains(['client_secret_basic', 'client_secret_post', 'none'], reg.token_endpoint_auth_method)) {
 		res.status(400).json({error: 'invalid_client_metadata'});
 		return;
 	}
@@ -651,7 +651,7 @@ app.post('/register', function (req, res){
 	}
 
 	reg.client_id = randomstring.generate();
-	if (__.contains(['secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
+	if (__.contains(['client_secret_basic', 'client_secret_post']), reg.token_endpoint_auth_method) {
 		reg.client_secret = randomstring.generate();
 	}
 

--- a/exercises/ch-8-ex-3/client.js
+++ b/exercises/ch-8-ex-3/client.js
@@ -98,7 +98,7 @@ var registerClient = function() {
 		redirect_uris: ['http://localhost:9000/callback'],
 		grant_types: ['authorization_code'],
 		response_types: ['code'],
-		token_endpoint_auth_method: 'secret_basic',
+		token_endpoint_auth_method: 'client_secret_basic',
 		scope: 'openid profile email address phone'
 	};
 

--- a/exercises/ch-9-ex-1/client.js
+++ b/exercises/ch-9-ex-1/client.js
@@ -98,7 +98,7 @@ var registerClient = function() {
 		redirect_uris: ['http://localhost:9000/callback'],
 		grant_types: ['authorization_code'],
 		response_types: ['code'],
-		token_endpoint_auth_method: 'secret_basic',
+		token_endpoint_auth_method: 'client_secret_basic',
 		scope: 'openid profile email address phone'
 	};
 

--- a/exercises/ch-9-ex-2/client.js
+++ b/exercises/ch-9-ex-2/client.js
@@ -98,7 +98,7 @@ var registerClient = function() {
 		redirect_uris: ['http://localhost:9000/callback'],
 		grant_types: ['authorization_code'],
 		response_types: ['code'],
-		token_endpoint_auth_method: 'secret_basic',
+		token_endpoint_auth_method: 'client_secret_basic',
 		scope: 'openid profile email address phone'
 	};
 


### PR DESCRIPTION
Hi
I found that 'register' function comparing the token_endpoint_auth_method is different from RFC-7591.
So I modify token_endpoint_auth_method as RFC-7591's 'client_secret_basic' and 'client_secret_post'.

Please review this issue, thanks.